### PR TITLE
Correction of Suggest struct Score type.

### DIFF
--- a/spell-check/types.go
+++ b/spell-check/types.go
@@ -30,5 +30,5 @@ type FlaggedToken struct {
 
 type Suggest struct {
 	Suggestion string `json:"suggestion"`
-	Score      int    `json:"score"`
+	Score      float64    `json:"score"`
 }


### PR DESCRIPTION
Hi! Bing spell check api returning float point numbers for suggestion score field. Values like: 0.929935891691776. So, because of int type in Suggest struct (Score field) json Unmarshal error rise. Thank you!